### PR TITLE
Fix timestamps on events

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,18 @@ Circuits.GPIO.Chip.listen_event("gpiochip0", 27)
 
 When an event is received from the line it will be in the form of:
 
-```
+```elixir
 {:circuits_cdev, pin_number, timestamp, new_value}
 ```
 
+The `timestamp` is the unix time in nanoseconds. In order to convert it into a
+`DateTime` you will need to pass the `:nanoseconds` as the unit to
+`DateTime.from_unix/3` function:
 
+```elixir
+DateTime.from_unix(timestamp, :nanoseconds)
+{:ok, ~U[1990-07-24 07:30:03.123456Z]}
+```
+
+Also when calculating the time delta between two events keep in mind the
+difference will be nanoseconds.

--- a/src/cdev_nif.c
+++ b/src/cdev_nif.c
@@ -166,7 +166,7 @@ static ERL_NIF_TERM read_event_data_nif(ErlNifEnv *env, int argc, const ERL_NIF_
         return common_make_error(env, enif_make_atom(env, "read_event_data_failed"));
 
     ERL_NIF_TERM value = enif_make_int(env, event_data->id);
-    ERL_NIF_TERM timestamp = enif_make_int(env, event_data->timestamp);
+    ERL_NIF_TERM timestamp = enif_make_uint64(env, event_data->timestamp);
 
     return enif_make_tuple3(env, priv->atom_ok, value, timestamp);
 

--- a/src/gpio_chip.c
+++ b/src/gpio_chip.c
@@ -97,7 +97,7 @@ int chip_read_event_data(struct gpio_chip_event_handle *handle, struct gpio_chip
         return -1;
 
     data->timestamp = event_data.timestamp;
-    data->id = (int)event_data.id;
+    data->id = event_data.id;
 
     return 0;
 }

--- a/src/gpio_chip.h
+++ b/src/gpio_chip.h
@@ -5,6 +5,7 @@
 #define GPIO_CHIP_H
 
 #include <linux/gpio.h>
+#include <stdint.h>
 #include "erl_nif.h"
 
 #define GPIO_CHIP_LINE_INPUT 0x00
@@ -44,7 +45,7 @@ struct gpio_chip_event_handle {
  * Struct for event data
  */
 struct gpio_chip_event_data {
-    int timestamp;
+    uint64_t timestamp;
     int id;
 };
 


### PR DESCRIPTION
The event was reporting some crazy numbers from before 1970 and
sometimes with a 10 year difference between events that took place
within seconds.

The code was losing information as it was forcing a 64 bit number into a
32 bit number. This fix provides the correct timestamp in
nanoseconds.