### PR TITLE
fix module names that were not renamed

### DIFF
--- a/lib/cdev.ex
+++ b/lib/cdev.ex
@@ -61,7 +61,7 @@ defmodule Circuits.Cdev do
   information.
 
   The `:input` direction means you can only read the current value of the GPIOs
-  on the line. See `Circuits.GPIO.read_value/1` for more information.
+  on the line. See `Circuits.Cdev.read_value/1` for more information.
   """
   @type line_direction() :: :input | :output
 

--- a/lib/cdev/application.ex
+++ b/lib/cdev/application.ex
@@ -8,7 +8,7 @@ defmodule Circuits.Cdev.Application do
       Circuits.Cdev.Events
     ]
 
-    opts = [strategy: :rest_for_one, name: Circuits.GPIO.Chip.Supervisor]
+    opts = [strategy: :rest_for_one, name: Circuits.Cdev.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end

--- a/src/cdev_nif.c
+++ b/src/cdev_nif.c
@@ -302,4 +302,4 @@ static ErlNifFunc nif_funcs[] = {
     {"set_values_nif", 2, set_values_nif, 0}
 };
 
-ERL_NIF_INIT(Elixir.Circuits.GPIO.Nif, nif_funcs, load, NULL, NULL, NULL)
+ERL_NIF_INIT(Elixir.Circuits.Cdev.Nif, nif_funcs, load, NULL, NULL, NULL)

--- a/test/circuits_cdev_test.exs
+++ b/test/circuits_cdev_test.exs
@@ -1,2 +1,2 @@
-defmodule Circuits.GPIO.Chip.Test do
+defmodule Circuits.Cdev.Test do
 end


### PR DESCRIPTION
This fix following error.

```
=SUPERVISOR REPORT==== 23-Jul-2022::07:54:11.942998 ===
    supervisor: {local,kernel_sup}
    errorContext: start_error
    reason: {on_load_function_failed,'Elixir.Circuits.Cdev.Nif',
                {error,
                    {bad_lib,
                        "Library module name 'Elixir.Circuits.GPIO.Nif' does not match calling module ''Elixir.Circuits.Cdev.Nif''"}}}
    offender: [{pid,undefined},
               {id,kernel_safe_sup},
               {mfargs,{supervisor,start_link,
                                   [{local,kernel_safe_sup},kernel,safe]}},
               {restart_type,permanent},
               {significant,false},
               {shutdown,infinity},
               {child_type,supervisor}]
```

How about make new tag 0.2.0 as renamed library?